### PR TITLE
Made createbucket not restart

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,6 +41,7 @@ services:
 
   createbucket:
     image: minio/mc:latest
+    restart: "no"
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
Made createbucket not restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production configuration to disable automatic restart behavior for the bucket creation service, requiring manual intervention if the service exits unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->