### PR TITLE
Fix production profile image upload and loading issues.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ MINIO_ACCESS_KEY=your-minio-access-key
 MINIO_SECRET_KEY=your-minio-secret-key
 MINIO_BUCKET_NAME=interview-service
 MINIO_ENDPOINT_URL=http://minio:9000
+MINIO_PUBLIC_URL=your-domain.com/interview-service
 
 # Stripe
 STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,6 +51,7 @@ services:
       /bin/sh -c "
       mc alias set myminio http://minio:9000 $${MINIO_ACCESS_KEY} $${MINIO_SECRET_KEY};
       mc mb myminio/$${MINIO_BUCKET_NAME} --ignore-existing;
+      mc anonymous set public myminio/$${MINIO_BUCKET_NAME};
       exit 0;
       "
 

--- a/interview_service/settings/base.py
+++ b/interview_service/settings/base.py
@@ -18,6 +18,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "storages",
     # Local apps
     "accounts",
     "interviewers",

--- a/interview_service/settings/dev.py
+++ b/interview_service/settings/dev.py
@@ -25,4 +25,7 @@ INSTALLED_APPS += ["django_browser_reload"]  # noqa: F405
 MIDDLEWARE += ["django_browser_reload.middleware.BrowserReloadMiddleware"]  # noqa: F405
 
 # Use local file storage in development
-DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+STORAGES = {
+    "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+    "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
+}

--- a/interview_service/settings/prod.py
+++ b/interview_service/settings/prod.py
@@ -28,16 +28,18 @@ DATABASES = {
 
 # WhiteNoise for static files
 MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")  # noqa: F405
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # MinIO / S3 storage for media files
-DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+STORAGES = {
+    "default": {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage"},
+    "staticfiles": {"BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"},
+}
 AWS_ACCESS_KEY_ID = os.environ.get("MINIO_ACCESS_KEY")
 AWS_SECRET_ACCESS_KEY = os.environ.get("MINIO_SECRET_KEY")
 AWS_STORAGE_BUCKET_NAME = os.environ.get("MINIO_BUCKET_NAME", "interview-service")
 AWS_S3_ENDPOINT_URL = os.environ.get("MINIO_ENDPOINT_URL")
+AWS_S3_CUSTOM_DOMAIN = os.environ.get("MINIO_PUBLIC_URL")
 AWS_S3_FILE_OVERWRITE = False
-AWS_DEFAULT_ACL = None
 AWS_S3_SIGNATURE_VERSION = "s3v4"
 AWS_S3_REGION_NAME = "us-east-1"
 

--- a/interview_service/settings/prod.py
+++ b/interview_service/settings/prod.py
@@ -40,6 +40,7 @@ AWS_STORAGE_BUCKET_NAME = os.environ.get("MINIO_BUCKET_NAME", "interview-service
 AWS_S3_ENDPOINT_URL = os.environ.get("MINIO_ENDPOINT_URL")
 AWS_S3_CUSTOM_DOMAIN = os.environ.get("MINIO_PUBLIC_URL")
 AWS_S3_FILE_OVERWRITE = False
+AWS_DEFAULT_ACL = "public-read"
 AWS_S3_SIGNATURE_VERSION = "s3v4"
 AWS_S3_REGION_NAME = "us-east-1"
 


### PR DESCRIPTION
Hello,

This is to address issue: https://github.com/508-dev/interview-as-a-service/issues/10

The production file configurations are still pointing to the local filesystem for storage, rather than using the `storages` module as the S3/MinIO storage backend. I was able to reproduce this issue while running in production mode compared to development and found the media file uploads in the local location.

* Switched from legacy `DEFAULT_FILE_STORAGE` and `STATICFILES_STORAGE` settings to the new `STORAGES` dictionary in both `dev.py` and `prod.py`, allowing separate backends for default and static files. 
* In production, set static files to use WhiteNoise's compressed manifest storage and media files to use S3/MinIO storage backend via `storages.backends.s3boto3.S3Boto3Storage`.
* In development, explicitly set default and static file storage backends using the new `STORAGES` setting.

Django Docs referencing the updated `storages` config:
https://docs.djangoproject.com/en/5.1/ref/settings/#storages

Some additional changes to serve public facing images (profile images) from MinIO/S3:
* Added support for a custom public domain for S3/MinIO by setting `AWS_S3_CUSTOM_DOMAIN` from the environment.
* Updated the MinIO initialization command in `docker-compose.prod.yml` to make the bucket publicly accessible.

Please note I've set the configured `$MINIO_BUCKET_NAME` to set `public-read` as opposed to pre-signed urls since they are static files to be served publicly. **One thing to consider are public facing files/media should be in a separate bucket than private files, so please let me know if this is to be implemented separately.**

Additionally, `MINIO_PUBLIC_URL` is now a new required environment variable in order to serve media upload files from the correct host. I've added the example in `.env.example`.

Let me know if any questions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured S3-compatible storage to make uploaded media files publicly accessible.

* **Chores**
  * Reorganized file storage backend configuration for development and production environments.
  * Added `MINIO_PUBLIC_URL` environment variable requirement for production storage domain setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->